### PR TITLE
Hide world map button, pause Vore, remove dead code

### DIFF
--- a/Game.html
+++ b/Game.html
@@ -79,6 +79,7 @@
 
 	<div id="map" class="None">
 		<canvas id="hem"></canvas>
+		<input type="button" id="HideWorldMap" value="Hide" />
 		<div id="WorldMapContainer">
 			<canvas id="WorldMap"></canvas>
 			<p id="StatusArea">Start</p>

--- a/Gamescript.js
+++ b/Gamescript.js
@@ -1469,7 +1469,9 @@
         }
         if (Settings.Vore) {
             document.getElementById("VoreLooks").style.display = 'inline-block';
-            VoreEngine();
+            if (!battle) {
+                VoreEngine();
+            }
         }
         if (TF.Status) {
             TfEngine();

--- a/JavaScript/PrintMap.js
+++ b/JavaScript/PrintMap.js
@@ -1,3 +1,14 @@
+
+document.getElementById("HideWorldMap").addEventListener("click", function () {
+    if (document.getElementById("WorldMapContainer").style.display == 'none') {
+        document.getElementById("WorldMapContainer").style.display = 'block';
+        PrintMap();
+        document.getElementById("HideWorldMap").value = "Hide";
+    } else {
+        document.getElementById("WorldMapContainer").style.display = 'none';
+        document.getElementById("HideWorldMap").value = "Show";
+    }
+});
 var WorldMap = document.getElementById("WorldMap");
 var World = WorldMap.getContext("2d");
 
@@ -10,7 +21,7 @@ function TilePainter(x, y, w, h) {
 
 }
 
-function PrintMap(karta) {
+function PrintMap(karta=null) {
     World.fillStyle = "#404040";
     World.fillRect(0, 0, WorldMap.width, WorldMap.height);
 

--- a/JavaScript/Vore.js
+++ b/JavaScript/Vore.js
@@ -1090,16 +1090,6 @@
         }
     }
 
-    function VoreCapacity(vorePart) {
-        var capacity = 0;
-        if (typeof vorePart == "array")
-            for (var innerVorePart of vorePart)
-                capacity += VoreCapacity(innerVorePart);
-        else
-            capacity += vorePart.Size || 0;
-        return capacity
-    }
-
     function StomachCapacity() {
         var capacity = player.Height / 3
         var sub = 0;

--- a/Stil.css
+++ b/Stil.css
@@ -263,6 +263,15 @@
        text-align: center;
    }
 
+   #HideWorldMap {
+       position: absolute;
+       right: 3vh;
+       top: 50vh;
+       height: 5vh;
+       width: 10vh;
+       text-align: center;
+   }
+
    @media (max-width: 700px) {
        #WorldMap {
            right: 0;


### PR DESCRIPTION
- add a button to show/hide the minimap
 - this is because when the window is not wide enough the minimap appears over the game map
 - please adjust the button position to your liking. I would like it next to the map title
   but the button was not clickable. I've never used CSS before.
- remove a recursive function in Vore.
 - I was trying to make a generic capacity function. I would have change the Stomach.
- pause Vore digestion during battle
- add a default value to the PrintMap parameter
 - I think this parameter is no longer used? 